### PR TITLE
Enhance planner UI and tax modeling

### DIFF
--- a/sunset-planner/src/components/OperatingForm.tsx
+++ b/sunset-planner/src/components/OperatingForm.tsx
@@ -22,11 +22,26 @@ export function OperatingForm() {
 
   return (
     <form onBlur={handleSubmit(onSubmit)} className="space-y-2">
-      <input type="number" className="input" placeholder="Property Tax" {...register('propTax', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Tax Growth" {...register('taxGrowth', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Insurance" {...register('insurance', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Ins Growth" {...register('insGrowth', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Maintenance %" {...register('maintenancePct', { valueAsNumber: true })} />
+      <label className="block">
+        <span className="label">Property Tax</span>
+        <input type="number" className="input" {...register('propTax', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Tax Growth</span>
+        <input type="number" step="0.01" className="input" {...register('taxGrowth', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Insurance</span>
+        <input type="number" className="input" {...register('insurance', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Ins Growth</span>
+        <input type="number" step="0.01" className="input" {...register('insGrowth', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Maintenance %</span>
+        <input type="number" step="0.01" className="input" {...register('maintenancePct', { valueAsNumber: true })} />
+      </label>
     </form>
   )
 }

--- a/sunset-planner/src/components/PropertyForm.tsx
+++ b/sunset-planner/src/components/PropertyForm.tsx
@@ -24,13 +24,34 @@ export function PropertyForm() {
 
   return (
     <form onBlur={handleSubmit(onSubmit)} className="space-y-2">
-      <input className="input" placeholder="Address" {...register('address')} />
-      <input type="number" className="input" placeholder="Purchase Price" {...register('purchasePrice', { valueAsNumber: true })} />
-      <input type="date" className="input" {...register('purchaseDate')} />
-      <input type="number" className="input" placeholder="Market Value" {...register('marketValue', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Mortgage Balance" {...register('mortgageBalance', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Rate" {...register('rate', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Term" {...register('term', { valueAsNumber: true })} />
+      <label className="block">
+        <span className="label">Address</span>
+        <input className="input" {...register('address')} />
+      </label>
+      <label className="block">
+        <span className="label">Purchase Price</span>
+        <input type="number" className="input" {...register('purchasePrice', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Purchase Date</span>
+        <input type="date" className="input" {...register('purchaseDate')} />
+      </label>
+      <label className="block">
+        <span className="label">Market Value</span>
+        <input type="number" className="input" {...register('marketValue', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Mortgage Balance</span>
+        <input type="number" className="input" {...register('mortgageBalance', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Rate</span>
+        <input type="number" step="0.01" className="input" {...register('rate', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Term (yrs)</span>
+        <input type="number" className="input" {...register('term', { valueAsNumber: true })} />
+      </label>
     </form>
   )
 }

--- a/sunset-planner/src/components/RentalForm.tsx
+++ b/sunset-planner/src/components/RentalForm.tsx
@@ -24,14 +24,38 @@ export function RentalForm() {
 
   return (
     <form onBlur={handleSubmit(onSubmit)} className="space-y-2">
-      <input type="number" className="input" placeholder="Nightly" {...register('nightly', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Occupancy" {...register('occupancy', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Fee %" {...register('feePct', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Cleaning" {...register('cleaning', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Mgmt %" {...register('mgmtPct', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Linens" {...register('linens', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Effort Hours" {...register('effortHours', { valueAsNumber: true })} />
-      <input type="number" className="input" placeholder="Effort Rate" {...register('effortRate', { valueAsNumber: true })} />
+      <label className="block">
+        <span className="label">Nightly Rate</span>
+        <input type="number" className="input" {...register('nightly', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Occupancy</span>
+        <input type="number" step="0.01" className="input" {...register('occupancy', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Fee %</span>
+        <input type="number" step="0.01" className="input" {...register('feePct', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Cleaning</span>
+        <input type="number" className="input" {...register('cleaning', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Mgmt %</span>
+        <input type="number" step="0.01" className="input" {...register('mgmtPct', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Linens</span>
+        <input type="number" className="input" {...register('linens', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Effort Hours</span>
+        <input type="number" className="input" {...register('effortHours', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Effort Rate</span>
+        <input type="number" className="input" {...register('effortRate', { valueAsNumber: true })} />
+      </label>
     </form>
   )
 }

--- a/sunset-planner/src/components/SaleForm.tsx
+++ b/sunset-planner/src/components/SaleForm.tsx
@@ -7,6 +7,7 @@ const schema = z.object({
   yearsAhead: z.number(),
   sellCostPct: z.number(),
   appreciation: z.number(),
+  homeSaleExclusion: z.boolean(),
 })
 
 export function SaleForm() {
@@ -19,9 +20,22 @@ export function SaleForm() {
 
   return (
     <form onBlur={handleSubmit(onSubmit)} className="space-y-2">
-      <input type="number" className="input" placeholder="Years Ahead" {...register('yearsAhead', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Sell Cost %" {...register('sellCostPct', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Appreciation" {...register('appreciation', { valueAsNumber: true })} />
+      <label className="block">
+        <span className="label">Years Ahead</span>
+        <input type="number" className="input" {...register('yearsAhead', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Sell Cost %</span>
+        <input type="number" step="0.01" className="input" {...register('sellCostPct', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Appreciation</span>
+        <input type="number" step="0.01" className="input" {...register('appreciation', { valueAsNumber: true })} />
+      </label>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" className="" {...register('homeSaleExclusion')} />
+        <span className="label m-0">$500k Home Sale Exclusion</span>
+      </label>
     </form>
   )
 }

--- a/sunset-planner/src/components/TaxForm.tsx
+++ b/sunset-planner/src/components/TaxForm.tsx
@@ -21,11 +21,26 @@ export function TaxForm() {
 
   return (
     <form onBlur={handleSubmit(onSubmit)} className="space-y-2">
-      <input type="number" step="0.01" className="input" placeholder="Fed Ord" {...register('fedOrd', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="NJ Ord" {...register('njOrd', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Fed CG" {...register('fedCG', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="NJ CG" {...register('njCG', { valueAsNumber: true })} />
-      <input type="number" step="0.01" className="input" placeholder="Recapture" {...register('recapture', { valueAsNumber: true })} />
+      <label className="block">
+        <span className="label">Fed Ord</span>
+        <input type="number" step="0.01" className="input" {...register('fedOrd', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">NJ Ord</span>
+        <input type="number" step="0.01" className="input" {...register('njOrd', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Fed CG</span>
+        <input type="number" step="0.01" className="input" {...register('fedCG', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">NJ CG</span>
+        <input type="number" step="0.01" className="input" {...register('njCG', { valueAsNumber: true })} />
+      </label>
+      <label className="block">
+        <span className="label">Recapture</span>
+        <input type="number" step="0.01" className="input" {...register('recapture', { valueAsNumber: true })} />
+      </label>
     </form>
   )
 }

--- a/sunset-planner/src/index.css
+++ b/sunset-planner/src/index.css
@@ -4,3 +4,4 @@
 
 /* custom global styles if needed */
 .input{ @apply border p-1 rounded w-full; }
+.label{ @apply block text-sm font-medium text-gray-700 mb-1; }

--- a/sunset-planner/src/lib/finance.ts
+++ b/sunset-planner/src/lib/finance.ts
@@ -10,7 +10,8 @@ export interface NPVResult {
 
 // Simplified NPV calculation for demonstration
 export function calcNPV(inputs: State): NPVResult {
-  const { rental, operating, sale, settings } = inputs
+  const { property, rental, operating, sale, tax, settings } = inputs
+
   const years = Array.from({ length: sale.yearsAhead }, (_, i) => i + 1)
 
   const cf = years.map(() => {
@@ -19,15 +20,36 @@ export function calcNPV(inputs: State): NPVResult {
       rental.nightly * 365 * rental.occupancy * rental.feePct -
       rental.cleaning -
       rental.nightly * 365 * rental.occupancy * rental.mgmtPct
+
     const expenses =
-      operating.propTax + operating.insurance + operating.maintenancePct * inputs.property.marketValue + rental.linens / sale.yearsAhead
+      operating.propTax +
+      operating.insurance +
+      operating.maintenancePct * property.marketValue +
+      rental.linens / sale.yearsAhead
+
     return rent - expenses
   })
 
+  const futureValue = property.marketValue * Math.pow(1 + sale.appreciation, sale.yearsAhead)
+  const salePrice = futureValue * (1 - sale.sellCostPct)
+  let taxableGain = futureValue - property.purchasePrice
+  if (sale.homeSaleExclusion) {
+    taxableGain = Math.max(0, taxableGain - 500000)
+  }
+  const taxes = taxableGain * (tax.fedCG + tax.njCG)
+  const saleCF = salePrice - property.mortgageBalance - taxes
+  cf[cf.length - 1] += saleCF
+
   const r = settings.discount
   const pvHold = cf.reduce((acc, val, i) => acc + val / Math.pow(1 + r, i + 1), 0)
-  const sellProceeds = inputs.property.marketValue * (1 - sale.sellCostPct)
-  const pvSell = sellProceeds / Math.pow(1 + r, 1)
+
+  const nowPrice = property.marketValue * (1 - sale.sellCostPct)
+  let nowGain = property.marketValue - property.purchasePrice
+  if (sale.homeSaleExclusion) {
+    nowGain = Math.max(0, nowGain - 500000)
+  }
+  const nowTaxes = nowGain * (tax.fedCG + tax.njCG)
+  const pvSell = nowPrice - property.mortgageBalance - nowTaxes
 
   return { pvHold, pvSell, delta: pvHold - pvSell, cf, years }
 }

--- a/sunset-planner/src/store/usePlannerStore.ts
+++ b/sunset-planner/src/store/usePlannerStore.ts
@@ -46,6 +46,7 @@ export interface Sale {
   yearsAhead: number
   sellCostPct: number
   appreciation: number
+  homeSaleExclusion: boolean
 }
 
 export interface Settings {
@@ -100,6 +101,7 @@ const defaultState: State = {
     yearsAhead: 20,
     sellCostPct: 0.06,
     appreciation: 0.03,
+    homeSaleExclusion: true,
   },
   settings: {
     discount: 0.05,
@@ -114,7 +116,7 @@ export const usePlannerStore = create<PlannerStore>()(
   persist(
     (set) => ({
       ...defaultState,
-      update: (partial) => set(partial as any),
+      update: (partial) => set(partial),
     }),
     { name: 'sunset-planner' }
   )


### PR DESCRIPTION
## Summary
- improve styling for forms with labels
- add checkbox for $500k home sale exclusion
- implement appreciation and after-tax sale cash flow in NPV

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862bb1ee9f0832c82543e8564d1c205