### PR TITLE
Improve scenario UI and show derived inputs

### DIFF
--- a/sunset-planner/src/App.tsx
+++ b/sunset-planner/src/App.tsx
@@ -20,11 +20,28 @@ function App() {
           <button className={tab === 'hold' ? 'font-bold' : ''} onClick={() => setTab('hold')}>Hold & Rent</button>
           <button className={tab === 'sell' ? 'font-bold' : ''} onClick={() => setTab('sell')}>Sell</button>
         </div>
-        <PropertyForm />
-        {tab === 'hold' && <RentalForm />}
-        <OperatingForm />
-        <TaxForm />
-        <SaleForm />
+        <section className="p-4 border rounded space-y-2">
+          <h2 className="font-bold">Property</h2>
+          <PropertyForm />
+        </section>
+        {tab === 'hold' && (
+          <section className="p-4 border rounded space-y-2">
+            <h2 className="font-bold">Rental</h2>
+            <RentalForm />
+          </section>
+        )}
+        <section className="p-4 border rounded space-y-2">
+          <h2 className="font-bold">Operating</h2>
+          <OperatingForm />
+        </section>
+        <section className="p-4 border rounded space-y-2">
+          <h2 className="font-bold">Tax</h2>
+          <TaxForm />
+        </section>
+        <section className="p-4 border rounded space-y-2">
+          <h2 className="font-bold">Sale</h2>
+          <SaleForm />
+        </section>
       </div>
       <div className="space-y-4">
         <ResultsCard />

--- a/sunset-planner/src/components/CashFlowChart.tsx
+++ b/sunset-planner/src/components/CashFlowChart.tsx
@@ -7,6 +7,7 @@ export function CashFlowChart() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const state = usePlannerStore()
   const result = calcNPV(state)
+  const sellCF = [result.pvSell, ...Array(result.cf.length - 1).fill(0)]
 
   useEffect(() => {
     if (!canvasRef.current) return
@@ -15,7 +16,8 @@ export function CashFlowChart() {
       data: {
         labels: result.years,
         datasets: [
-          { label: 'Cash Flow', data: result.cf, backgroundColor: 'rgba(99,102,241,0.5)' },
+          { label: 'Hold & Rent', data: result.cf, backgroundColor: 'rgba(99,102,241,0.5)' },
+          { label: 'Sell Now', data: sellCF, backgroundColor: 'rgba(239,68,68,0.5)' },
         ],
       },
     })

--- a/sunset-planner/src/components/ResultsCard.tsx
+++ b/sunset-planner/src/components/ResultsCard.tsx
@@ -1,15 +1,35 @@
 import { usePlannerStore } from '../store/usePlannerStore'
-import { calcNPV } from '../lib/finance'
+import { calcNPV, calcDerived } from '../lib/finance'
 
 export function ResultsCard() {
   const state = usePlannerStore()
   const result = calcNPV(state)
+  const derived = calcDerived(state)
 
   return (
-    <div className="p-4 border rounded space-y-2">
-      <div>PV Hold: <b>{result.pvHold.toFixed(0)}</b></div>
-      <div>PV Sell: <b>{result.pvSell.toFixed(0)}</b></div>
-      <div>Delta: <b>{result.delta.toFixed(0)}</b></div>
+    <div className="p-4 border rounded space-y-4">
+      <div className="space-y-1 text-sm">
+        <div className="font-bold text-lg">Derived Inputs</div>
+        <div>Mortgage Payment: {derived.mortgagePayment.toFixed(0)}</div>
+        <div>Annual Gross Rent: {derived.grossRent.toFixed(0)}</div>
+        <div>Annual Net Rent: {derived.netRent.toFixed(0)}</div>
+      </div>
+      <div className="grid md:grid-cols-2 gap-4 text-sm">
+        <div>
+          <div className="font-bold">Scenario 1: Hold &amp; Rent</div>
+          <div>PV: {result.pvHold.toFixed(0)}</div>
+          <ul className="list-disc pl-4">
+            {result.cf.map((v, i) => (
+              <li key={i}>Year {i + 1}: {v.toFixed(0)}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <div className="font-bold">Scenario 2: Sell Now</div>
+          <div>PV: {result.pvSell.toFixed(0)}</div>
+        </div>
+      </div>
+      <div className="font-bold">Delta: {result.delta.toFixed(0)}</div>
     </div>
   )
 }

--- a/sunset-planner/src/lib/finance.ts
+++ b/sunset-planner/src/lib/finance.ts
@@ -8,6 +8,31 @@ export interface NPVResult {
   years: number[]
 }
 
+export interface Derived {
+  mortgagePayment: number
+  grossRent: number
+  netRent: number
+}
+
+export function calcDerived(state: State): Derived {
+  const { property, rental } = state
+
+  const monthlyRate = property.rate / 12
+  const n = property.term * 12
+  const mortgagePayment =
+    (property.mortgageBalance * monthlyRate) /
+    (1 - Math.pow(1 + monthlyRate, -n))
+
+  const grossRent = rental.nightly * 365 * rental.occupancy
+  const netRent =
+    grossRent -
+    grossRent * rental.feePct -
+    rental.cleaning -
+    grossRent * rental.mgmtPct
+
+  return { mortgagePayment, grossRent, netRent }
+}
+
 // Simplified NPV calculation for demonstration
 export function calcNPV(inputs: State): NPVResult {
   const { property, rental, operating, sale, tax, settings } = inputs


### PR DESCRIPTION
## Summary
- group input forms into clearly labeled sections
- show hold vs sell cash flows in the chart
- display derived values such as mortgage payment and net rent
- list cash flows and PV for each scenario

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862c68aee90832ca81a429e67987c91